### PR TITLE
Fix undefined variable $roles

### DIFF
--- a/app/Http/Controllers/Admin/AccessControlController.php
+++ b/app/Http/Controllers/Admin/AccessControlController.php
@@ -32,7 +32,12 @@ class AccessControlController extends Controller
             ->limit(10)
             ->get();
 
-        return view('admin.access-control.index', compact('stats', 'recent_role_assignments'));
+        // Add the missing variables that the view expects
+        $roles = Role::withCount('users')->get();
+        $permissions = Permission::all();
+        $totalUsers = User::count();
+
+        return view('admin.access-control.index', compact('stats', 'recent_role_assignments', 'roles', 'permissions', 'totalUsers'));
     }
 
     /**


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Pass `$roles`, `$permissions`, and `$totalUsers` to the access control index view to resolve undefined variable errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `admin.access-control.index.blade.php` view expected these variables for displaying statistics and lists, but the `AccessControlController@index` method was not passing them, leading to "Undefined variable" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0354d6c4-c6b0-4233-9b60-d69083065c46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0354d6c4-c6b0-4233-9b60-d69083065c46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>